### PR TITLE
chore(ci): drop Python 3.9, add 3.14, float pypi-publish to v1

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.9, '3.10', 3.11, 3.12, 3.13]
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Build package
       run: python -m build
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@release/v1.12
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.PYPI_PASSWORD_OPENKIM }}

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -42,7 +42,7 @@ Installation
 Requirements
 ~~~~~~~~~~~~~~~~~~~~~~
 
-``kim-convergence`` requires **Python 3.9 or later**. Download installers for
+``kim-convergence`` requires **Python 3.10 or later**. Download installers for
 all platforms from the `official Python website <https://www.python.org/getit/>`_.
 
 Using uv (Recommended)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [{ name = "Yaser Afshar", email = "ya.afshar@gmail.com" }]
 maintainers = [{ name = "Yaser Afshar", email = "ya.afshar@gmail.com" }]
 description = "kim-convergence designed to help in automatic equilibration detection & run length control."
 readme = { file = "README.md", content-type = "text/markdown" }
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = { text = "LGPL-2.1-or-later" }
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -18,11 +18,11 @@ classifiers = [
     "Topic :: Scientific/Engineering",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 dynamic = [ "version" ]
 keywords = [ "convergence", "automated equilibration detection", "run length control",


### PR DESCRIPTION
## Summary

Python 3.9 reached end-of-life (Oct 2025) and 3.14 is now the current stable
release. This updates the supported version range across packaging, CI, and
docs, and floats the PyPI publish action to its major-version tag.

## Changes

- **pyproject.toml**
  - Bump `requires-python` to `>=3.10`
  - Update classifiers: drop 3.9, add 3.14
- **.github/workflows/python-package.yml**
  - Update test matrix to `3.10`–`3.14`
- **.github/workflows/python-publish.yml**
  - Float `pypa/gh-action-pypi-publish` to `@release/v1`
- **doc/getting_started.rst**
  - Update minimum Python requirement to 3.10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated minimum supported Python version from 3.9 to 3.10
  * Expanded CI testing to include Python 3.14 (dropping Python 3.9)
  * Adjusted package publishing workflow to use the newer release action reference
* **Documentation**
  * Updated Getting Started instructions to require Python 3.10 or later
<!-- end of auto-generated comment: release notes by coderabbit.ai -->