### PR TITLE
ci: run ASE integration tests on Ubuntu

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -20,6 +20,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e .
+    - name: Install ASE for integration tests (Ubuntu only)
+      if: runner.os == 'Linux'
+      run: pip install -e ".[ase]"
     - name: Lint with flake8
       run: |
         pip install flake8==7.1.2 flake8-pyproject==1.2.3


### PR DESCRIPTION
## Summary

The ASE integration tests in `tests/test_kim_convergence/test_ase.py` are
guarded by `@unittest.skipUnless(HAS_ASE, "ASE not installed")`. CI only ran
`pip install -e .` (without the `ase` extra), so `HAS_ASE` was always `False`
and **all 24 ASE tests were silently skipped** on every job — the suite reported
green without ever exercising the ASE module.

## Change

- Add an Ubuntu-only step to `python-package.yml` that installs the `ase` extra:

  ```yaml
  - name: Install ASE for integration tests (Ubuntu only)
    if: runner.os == 'Linux'
    run: pip install -e ".[ase]"
