### PR TITLE
docs(examples): align LAMMPS example notation with example folder

### DIFF
--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -139,7 +139,7 @@ The LAMMPS integration works through LAMMPS's built-in Python interface.
    variable pea    equal "c_thermo_pe/v_natoms"
 
    # Call the Python function
-   python run_length_control input 4 SELF 1 variable pea format piss file run_length_control.py
+   python run_length_control input 4 SELF 1 variable pea format piss file cr_rlc_lammps.py
    python run_length_control invoke
 
 **Python function signature in LAMMPS context:**
@@ -164,13 +164,13 @@ Single variable:
 
 .. code-block:: bash
 
-   python run_length_control input 4 SELF 100 variable my_var format piss file run_length_control.py
+   python run_length_control input 4 SELF 100 variable my_var format piss file cr_rlc_lammps.py
 
 Multiple observables:
 
 .. code-block:: bash
 
-   python run_length_control input 6 SELF 10 variable energy compute temperature format pissss file run_length_control.py
+   python run_length_control input 6 SELF 10 variable energy compute temperature format pissss file cr_rlc_lammps.py
 
 6b. LAMMPS command (input-script fragment)
 ------------------------------------------
@@ -179,7 +179,7 @@ Add these two lines **after** your computes/variables are defined.
 
 .. code-block:: bash
 
-   python run_length_control input 4 SELF 100 v_pe format piss file run_length_control.py
+   python run_length_control input 4 SELF 100 variable pe format piss file cr_rlc_lammps.py
    python run_length_control invoke
 
 See :ref:`lammps-integration` above for Python implementation details.


### PR DESCRIPTION
## Summary

The LAMMPS integration sections in `doc/examples.rst` had drifted from the
actual code in `examples/lammps/`. Two issues:

1. **Wrong filename** — all four LAMMPS code blocks referenced
   `file run_length_control.py`, but the real entry point is
   `cr_rlc_lammps.py`. Anyone copy-pasting the docs would hit a missing-file
   error.

2. **Invalid variable notation** — section 6b used the direct-prefix form
   `v_pe`. The current argument parser (`_argument_parser.py`) requires the
   `variable`/`compute`/`fix` keyword form and raises
   `Input argument "v_pe" is not recognized.` for the prefixed token. This
   also contradicted section 6a, which already used `variable pea`.

## Changes

- Rename `run_length_control.py` → `cr_rlc_lammps.py` in all LAMMPS code
  blocks
- Change `v_pe` → `variable pe` in section 6b so it matches section 6a and
  the `in.lj*` example scripts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated LAMMPS integration examples with current script references
  * Revised command invocation patterns for single and multiple observable configurations
  * Refreshed example code fragments for accurate usage guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->