### PR TITLE
docs(ase): document ASE integration and wire up autodoc

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -107,3 +107,10 @@ CRSampleSizeError
 ~~~~~~~~~~~~~~~~~
 
 .. autoexception:: kim_convergence.err.CRSampleSizeError
+
+Optional Integrations
+---------------------
+
+ASE (Atomic Simulation Environment) integration is documented on its own page:
+see :doc:`modules/ase` for the ``ASESampler`` sampler, the
+``run_ase_equilibration`` driver, and the built-in property extractors.

--- a/doc/best_practices.rst
+++ b/doc/best_practices.rst
@@ -121,7 +121,7 @@ Common Pitfalls
 Integration with Simulators
 ---------------------------
 
-* **Callbacks** – Provided for LAMMPS and OpenMM; return an array of shape
+* **Callbacks** – Provided for LAMMPS, OpenMM, and ASE; return an array of shape
   ``(n_variables, n_steps)``.
 * **Custom codes** – Implement ``get_trajectory(step)`` or
   ``get_trajectory(step, args)`` and pass the same signature to

--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -184,7 +184,86 @@ Add these two lines **after** your computes/variables are defined.
 
 See :ref:`lammps-integration` above for Python implementation details.
 
-7. Batch re-analysis of existing files
+.. _ase-integration:
+
+7. ASE Integration
+------------------
+
+The :mod:`kim_convergence.ase` module drives an
+`ASE <https://ase-lib.org/>`_ ``MolecularDynamics`` object until the
+monitored property converges. It requires ASE (``pip install ase``).
+
+.. seealso::
+   Complete working example:
+   :download:`example_equilibration.py <../examples/ase/example_equilibration.py>`
+
+**Basic usage** – equilibrate a Cu system on temperature to 10 % accuracy:
+
+.. code-block:: python
+
+   from ase import units
+   from ase.build import bulk
+   from ase.calculators.emt import EMT
+   from ase.md.langevin import Langevin
+   from ase.md.velocitydistribution import MaxwellBoltzmannDistribution
+
+   from kim_convergence.ase import ASESampler, run_ase_equilibration
+
+   atoms = bulk("Cu", cubic=True) * (4, 4, 4)
+   atoms.calc = EMT()
+   MaxwellBoltzmannDistribution(atoms, temperature_K=600)
+
+   dyn = Langevin(atoms, timestep=5 * units.fs,
+                  temperature_K=500, friction=0.01 / units.fs)
+
+   sampler = ASESampler(dyn, property_names="temperature")
+   result = run_ase_equilibration(
+       sampler,
+       initial_run_length=500,
+       maximum_run_length=20000,
+       relative_accuracy=0.1,          # 10 %
+       confidence_coefficient=0.95)
+
+   if result["converged"]:
+       print(f"Equilibrated in {result['total_run_length']} samples")
+       print(f"Mean temperature : {result['mean']}")
+
+``run_ase_equilibration`` forwards all keyword arguments to
+:func:`kim_convergence.run_length_control` and returns its result dictionary
+(``get_trajectory``, ``fp``, and ``fp_format`` are reserved).
+
+**Multiple observables** – pass a list of property names:
+
+.. code-block:: python
+
+   sampler = ASESampler(dyn, property_names=["energy", "temperature"])
+
+**Sampling less frequently** – ``sample_interval`` collects a value every *N*
+MD steps (so ``initial_run_length`` samples run ``N * initial_run_length``
+steps):
+
+.. code-block:: python
+
+   sampler = ASESampler(dyn, property_names="energy", sample_interval=10)
+
+**Built-in properties:** ``energy`` (or ``potential_energy``),
+``kinetic_energy``, ``total_energy``, ``temperature``, ``volume``,
+``pressure``, ``density``.
+
+**Custom properties** – supply your own extractor (a callable taking an
+``Atoms`` object and returning a float):
+
+.. code-block:: python
+
+   def get_max_force(atoms):
+       return float(np.max(np.abs(atoms.get_forces())))
+
+   sampler = ASESampler(
+       dyn,
+       property_names="max_force",
+       extractors={"max_force": get_max_force})
+
+8. Batch re-analysis of existing files
 --------------------------------------
 
 Treat a long pre-computed series as a synthetic trajectory.

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -167,8 +167,8 @@ Key fields include ``converged``, ``total_run_length``, ``equilibration_step``,
 Integration with Simulation Packages
 ------------------------------------
 
-- **LAMMPS** and **OpenMM** are supported via dedicated callbacks (see
-  :doc:`examples` for full code).
+- **LAMMPS**, **OpenMM**, and **ASE** are supported via dedicated callbacks
+  (see :doc:`examples` for full code).
 - For **custom simulators**, simply provide a ``get_trajectory`` callable that
   returns a NumPy array.
 - Enable ``dump_trajectory=True`` to save raw data for debugging if convergence

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -34,6 +34,7 @@
    modules/stats
    modules/timeseries
    modules/other_utils
+   modules/ase
 
 .. toctree::
    :maxdepth: 2

--- a/doc/modules/ase.rst
+++ b/doc/modules/ase.rst
@@ -1,0 +1,60 @@
+ASE Integration Module
+======================
+
+Overview
+--------
+
+The :mod:`kim_convergence.ase` module connects kim-convergence to the
+`Atomic Simulation Environment (ASE) <https://ase-lib.org/>`_. It drives an
+ASE ``MolecularDynamics`` object in chunks, collects one or more properties
+through ASE's observer mechanism, and feeds them to
+:func:`kim_convergence.run_length_control` to automatically detect
+equilibration and control the run length.
+
+.. note::
+
+   This module is optional and requires ASE. Install it with::
+
+      pip install ase
+
+   or, together with kim-convergence::
+
+      pip install kim-convergence[ase]
+
+For a narrative, copy-paste-ready walkthrough see the
+:ref:`ASE Integration example <ase-integration>`. A complete runnable script
+is provided in ``examples/ase/example_equilibration.py``.
+
+Contents
+--------
+
+.. toctree::
+   :maxdepth: 2
+
+1. :ref:`Equilibration Driver <ase-equilibration>`
+2. :ref:`Property Extractors <ase-extractors>`
+
+.. _ase-equilibration:
+
+Equilibration Driver
+--------------------
+
+.. automodule:: kim_convergence.ase.equilibration
+   :members:
+   :exclude-members: __all__
+
+.. _ase-extractors:
+
+Property Extractors
+-------------------
+
+Built-in extractors map a property name to a callable that takes an ASE
+``Atoms`` object and returns a ``float``. The available names are ``energy``
+(or ``potential_energy``), ``kinetic_energy``, ``total_energy``,
+``temperature``, ``volume``, ``pressure``, and ``density``. Custom extractors
+can be supplied through the ``extractors`` argument of
+:class:`~kim_convergence.ase.ASESampler`.
+
+.. automodule:: kim_convergence.ase.extractors
+   :members:
+   :exclude-members: __all__

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -68,8 +68,8 @@ Key Features
 - **Time Series Analysis:** Tools for statistical inefficiency, autocorrelation,
   and sampling uncorrelated data.
 
-- **Integration-Friendly:** Works with LAMMPS, OpenMM, and custom simulators via
-  a callback API.
+- **Integration-Friendly:** Works with LAMMPS, OpenMM, ASE, and custom
+  simulators via a callback API.
 
 For installation and basic usage, see :doc:`getting_started`. For scientific
 details, see :doc:`theory` and the Core Modules section.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,4 +65,5 @@ doc = [
     "myst-parser",
     "sphinxcontrib-mermaid",
     "sphinx-design",
+    "ase",
 ]


### PR DESCRIPTION
## Summary

The `kim_convergence.ase` module: `ASESampler`, `run_ase_equilibration`, and
the property extractors, is a public, CI-tested feature, but it was missing
from the documentation entirely. Other modules have their inline docstrings
pulled into the docs via autodoc; ASE's were orphaned, and no narrative or API
page referenced the module.

This PR documents ASE the same way the other integrations and modules are
documented, and makes the Read the Docs build able to render it.

## Changes

- **Narrative example:** new "ASE Integration" section in `doc/examples.rst`
  covering basic usage, multiple observables, `sample_interval`, and
  built-in/custom property extractors.
- **API page:** new `doc/modules/ase.rst` with `automodule` autodoc for
  `kim_convergence.ase.equilibration` and `kim_convergence.ase.extractors`,
  added to the index toctree and cross-linked from `doc/api.rst`.
- **Integration lists:** ASE now listed alongside LAMMPS/OpenMM in
  `overview.rst`, `getting_started.rst`, and `best_practices.rst`.
- **Build fix:** added `ase` to the `doc` optional-dependencies extra.
  Without it, autodoc importing `kim_convergence.ase` hits the `ImportError`
  guard in `kim_convergence/ase/__init__.py` and the RTD build fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive ASE (Atomic Simulation Environment) integration documentation across API reference, examples, and guides
  * Updated getting started and overview sections to highlight ASE support alongside LAMMPS and OpenMM
  * Included ASE integration examples showing convergence usage and property extraction patterns

* **Chores**
  * Added ASE as an optional documentation dependency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->