### PR TITLE
Add workflow to send PR to KDP after publishing

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -26,3 +26,11 @@ jobs:
       with:
         user: __token__
         password: ${{ secrets.PYPI_PASSWORD_OPENKIM }}
+  send-pull-request-to-kdp:
+    uses: openkim/reusable-workflows/.github/workflows/upversion-pypi-package-and-send-pr.yml@main
+    secrets: inherit
+    with:
+      target-repository: developer-platform
+      target-repository-base-branch: main
+      recipe-file-path: docker/install/Dockerfile
+    needs: deploy        


### PR DESCRIPTION
This will automatically send a PR to upversion kim-convergence in the KIM Developer Platform Docker image every time a new version is published, eliminating the need to remember to upversion packages manually. `kim-convergence` already has access to the needed secret in the org settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment automation to streamline version updates and synchronization with dependent systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->